### PR TITLE
fix(package.json): use git+https instead of http for repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "http://github.com/colorjs/color-name.git"
+    "url": "git+https://github.com/colorjs/color-name.git"
   },
   "keywords": [
     "color-name",


### PR DESCRIPTION
## Summary

The published `color-name@2.1.0` npm metadata exposes `repository.url` as `http://github.com/colorjs/color-name.git`, which is not the canonical form expected by npm and downstream tooling.

## Bug

`npm view color-name repository.url` returns `http://github.com/colorjs/color-name.git`. This is a non-canonical form:

- The `http://` scheme (vs `https://`) is not what npm expects for canonical public repo URLs.
- The lack of the `git+` prefix is treated as legacy by npm tooling.
- Tools that automatically clone/fetch from the repo URL (CI bots, dependency analyzers, package security scanners) may fail or follow redirects.

## Fix

Updated `package.json` `repository.url` from `http://github.com/colorjs/color-name.git` → `git+https://github.com/colorjs/color-name.git`. This is a 1-line, metadata-only change.

## Why this matters

- Aligns with the npm-published metadata convention used by sibling packages (e.g. `brace-expansion`).
- Makes the package machine-friendly for downstream tooling.
- After the next npm publish, `npm view color-name repository.url` will return the canonical form.

## Validation

- `node -e "const p=require('./package.json'); if (p.repository.url !== 'git+https://github.com/colorjs/color-name.git') process.exit(1)"` → exits 0
- `node test.js` → existing test suite passes (no test changes needed)
- No runtime code, dependency, or lockfile changes
- `git diff upstream/master -- package.json` → +1/-1 in 1 file

## Related

- `brace-expansion#115` (juliangruber/brace-expansion): same shape, merged 2026-06-20T09:09:37Z as a clear maintainer-side precedent.